### PR TITLE
Remove mention of single-staking being removed

### DIFF
--- a/pages/bmx.mdx
+++ b/pages/bmx.mdx
@@ -3,7 +3,7 @@
 
 - Website: https://bmx.morphex.trade/
 - Decentralized perpetual trading platform that launched on **BASE**
-- Not your typical GMX-fork: *single-staking* and *escrowed-tokens* have been **removed entirely**
+- Not your typical GMX-fork: *escrowed-tokens* have been **removed entirely**
 - **BMX** liquidity providers earn up to **90%** of *protocol revenue* and *other incentives* when utilizing GLP-equivalent liquidity to co-support native protocol-token liquidity.
 
 > “What we usually consider as impossible are simply engineering problems… there’s no law of physics preventing them.” - Michio Kaku


### PR DESCRIPTION
Single staking has been added and is currently live. Saying "single-staking and escrowed-tokens have been removed entirely" is now inaccurate.